### PR TITLE
…[bugfix] cameraExecutor shutdown problem

### DIFF
--- a/camerax-mlkit-pack/src/main/java/com/furkan/camerax_mlkit_pack/CameraxManager.kt
+++ b/camerax-mlkit-pack/src/main/java/com/furkan/camerax_mlkit_pack/CameraxManager.kt
@@ -149,6 +149,9 @@ class CameraxManager(
 
     fun startCamera() {
         addCameraProviderFeatureListener()
+        if(cameraExecutor.isShutdown || cameraExecutor.isTerminated) {
+            cameraExecutor = Executors.newSingleThreadExecutor()
+        }
     }
 
     fun stopCamera() {


### PR DESCRIPTION
[bugfix] if cameraExecutor shutdown or terminated re assign cameraExecutor in startCamera.